### PR TITLE
Correct path reference for farm solutions

### DIFF
--- a/content/docs/usage/installation.md
+++ b/content/docs/usage/installation.md
@@ -121,7 +121,7 @@ Do the following on the server running the central administration:
     Add-SPSolution -LiteralPath "C:\YvanData\dev\EntraCP.wsp"
     ```
 
-1. Navigate to the central administration > Security > Manage farm solutions > click on "entracp.wsp" > Deploy solution.
+1. Navigate to the central administration > System Settings > Manage farm solutions > click on "entracp.wsp" > Deploy solution.
 1. Monitor the deployment of the solution and wait for it to be fully deployed.
 1. Install the features present in the solution:
 


### PR DESCRIPTION
The path of farm solutions is located in system settings on Sharepoint 2019 and SE.

![image](https://github.com/user-attachments/assets/0d4909f7-8988-45e9-81b2-6ffa133e6b3c)


I do not know if it would be correct for older versions.